### PR TITLE
Introduce command and args Override, simple GPU affinity toleration 

### DIFF
--- a/charts/eb7-base/Chart.yaml
+++ b/charts/eb7-base/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.1.0
+appVersion: 0.2.0

--- a/charts/eb7-base/templates/_helpers.tpl
+++ b/charts/eb7-base/templates/_helpers.tpl
@@ -57,3 +57,36 @@ Because for everychange in the content, the name should be changed
 {{ include "app.fullname" . }}
 {{- end -}}
 {{- end -}}
+
+
+{{/*
+Create affinity rules to run on GPU or CPU nodes
+*/}}
+{{- define "app.affinityTolerationRules" -}}
+{{- if .Values.runOnGPU -}}
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: eks.amazonaws.com/nodegroup
+          operator: In
+          values:
+          - gpu-nodes
+tolerations:
+  - key: nodegroup
+    effect: NoSchedule
+    value: gpu-nodes
+    operator: Equal
+{{- else -}}
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: eks.amazonaws.com/nodegroup
+          operator: In
+          values:
+          - gp-nodes
+{{- end -}}
+{{- end -}}

--- a/charts/eb7-base/templates/daemonset.yaml
+++ b/charts/eb7-base/templates/daemonset.yaml
@@ -34,8 +34,11 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          {{- with .Values.args }}
-          args: {{- toYaml . | nindent 10}}
+          {{- with .Values.argsOverride }}
+          args: {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with .Values.commandOverride }}
+          command: {{- toYaml . | nindent 10 }}
           {{- end }}
           {{- with .Values.securityContext }}
           securityContext:
@@ -90,7 +93,7 @@ spec:
                   name: "{{ include "app.secretsProviderName" $ }}"
           {{- end }}
           {{- end }}
-          {{- if or (.Values.awsSecrets) (.Values.efsPvcVolumes) (.Values.hostVolumes) }}
+          {{- if or (.Values.awsSecrets) (.Values.persistentVolumes) (.Values.hostVolumes) }}
           volumeMounts:
           {{- if .Values.awsSecrets }}
             - mountPath: /mnt/secrets-store
@@ -104,14 +107,14 @@ spec:
               readOnly: {{ .readOnly | default "false" }}
           {{- end }}
           {{- end }}
-          {{- with .Values.efsPvcVolumes }}
+          {{- with .Values.persistentVolumes }}
           {{- range . }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
           {{- end }}
           {{- end }}
           {{- end }}
-      {{- if or (.Values.awsSecrets) (.Values.efsPvcVolumes) (.Values.hostVolumes) }}
+      {{- if or (.Values.awsSecrets) (.Values.persistentVolumes) (.Values.hostVolumes) }}
       volumes:
       {{- with .Values.awsSecrets }}
         - name: secrets-store-inline
@@ -128,7 +131,7 @@ spec:
             path: {{ .hostPath }}
       {{- end }}
       {{- end }}
-      {{- with .Values.efsPvcVolumes }}
+      {{- with .Values.persistentVolumes }}
       {{- range . }}
         - name: {{ .name }}
           persistentVolumeClaim:
@@ -140,12 +143,5 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- include "app.affinityTolerationRules" . | nindent 6 }}
 {{- end }}

--- a/charts/eb7-base/templates/deployment.yaml
+++ b/charts/eb7-base/templates/deployment.yaml
@@ -44,8 +44,11 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          {{- with .Values.args }}
-          args: {{- toYaml . | nindent 10}}
+          {{- with .Values.argsOverride }}
+          args: {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with .Values.commandOverride }}
+          command: {{- toYaml . | nindent 10 }}
           {{- end }}
           {{- with .Values.securityContext }}
           securityContext:
@@ -100,7 +103,7 @@ spec:
                   name: "{{ include "app.secretsProviderName" $ }}"
           {{- end }}
           {{- end }}
-          {{- if or (.Values.awsSecrets) (.Values.efsPvcVolumes) (.Values.hostVolumes) }}
+          {{- if or (.Values.awsSecrets) (.Values.persistentVolumes) (.Values.hostVolumes) }}
           volumeMounts:
           {{- if .Values.awsSecrets }}
             - mountPath: /mnt/secrets-store
@@ -114,14 +117,14 @@ spec:
               readOnly: {{ .readOnly | default "false" }}
           {{- end }}
           {{- end }}
-          {{- with .Values.efsPvcVolumes }}
+          {{- with .Values.persistentVolumes }}
           {{- range . }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
           {{- end }}
           {{- end }}
           {{- end }}
-      {{- if or (.Values.awsSecrets) (.Values.efsPvcVolumes) (.Values.hostVolumes) }}
+      {{- if or (.Values.awsSecrets) (.Values.persistentVolumes) (.Values.hostVolumes) }}
       volumes:
       {{- with .Values.awsSecrets }}
         - name: secrets-store-inline
@@ -138,7 +141,7 @@ spec:
             path: {{ .hostPath }}
       {{- end }}
       {{- end }}
-      {{- with .Values.efsPvcVolumes }}
+      {{- with .Values.persistentVolumes }}
       {{- range . }}
         - name: {{ .name }}
           persistentVolumeClaim:
@@ -150,12 +153,5 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- include "app.affinityTolerationRules" . | nindent 6 }}
 {{- end }}

--- a/charts/eb7-base/values.yaml
+++ b/charts/eb7-base/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: "ECR-Repo"
+  repository: "busybox"
   tag: latest
   pullPolicy: IfNotPresent
 
@@ -78,7 +78,7 @@ healthCheckProbes:
 
 
 # AWS_EFS_ID should be aquired from DevOps Team
-# efsPvcVolumes:
+# persistentVolumes:
 #   - name: efs-pvc1
 #     mountPath: /var/lib/efs-pvc1
 #     size: 6G
@@ -105,20 +105,17 @@ healthCheckProbes:
 # budget:
 #   minAvailable: 1
 
+# Enable and set to anything to run on GPU nodes
+# Otherwise, it will run on CPU nodes
+# runOnGPU: true
 
-# imagePullSecrets: []
-# nodeSelector: {}
-# tolerations: []
 
-affinity:
-  nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      nodeSelectorTerms:
-      - matchExpressions:
-        - key: eks.amazonaws.com/nodegroup
-          operator: In
-          values:
-          - gp-nodes
+# Container command and args override
+# commandOverride: ["/bin/sh"]
+# argsOverride: [
+#   "-c",
+#   "while true; do echo sleeping; sleep 10; done"
+# ]
 
 # lifecycle:
 #   preStop:
@@ -131,3 +128,7 @@ affinity:
 #   capabilities:
 #     add:
 #     - SYS_ADMIN
+
+
+# imagePullSecrets: []
+# nodeSelector: {}


### PR DESCRIPTION
Changes: 
- Rename `efsVolumes` to `persistentVolumes`
- Add simple `runOnGPU` to add affinity and tolerations automatically
- Command and Args override for apps like bot-engine-rest-auth