### PR TITLE
fix execution order

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Release Charts
 
 on:
-  push:
-    branches:
-      - master
   workflow_run:
     workflows: ["Lint and Test Charts"]
     types:


### PR DESCRIPTION
fixing a situation when the release gets executed two times:
- one on merge to master
- one after the test phase finishes.