### PR TITLE
Add flag runOnLocal to allow local deployments without pod affinity

### DIFF
--- a/charts/eb7-base/templates/_helpers.tpl
+++ b/charts/eb7-base/templates/_helpers.tpl
@@ -63,6 +63,7 @@ Because for everychange in the content, the name should be changed
 Create affinity rules to run on GPU or CPU nodes
 */}}
 {{- define "app.affinityTolerationRules" -}}
+{{- if not .Values.runOnLocal -}}
 {{- if .Values.runOnGPU -}}
 affinity:
   nodeAffinity:
@@ -88,5 +89,6 @@ affinity:
           operator: In
           values:
           - gp-nodes
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/eb7-base/templates/pdb.yaml
+++ b/charts/eb7-base/templates/pdb.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.budget -}}
-{{- if .Values.budget.minAvailable -}}
+{{- if .Values.budgetMinAvailable -}}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -8,9 +7,8 @@ metadata:
   labels:
     {{- include "app.labels" . | nindent 4 }}
 spec:
-  minAvailable: {{ .Values.budget.minAvailable }}
+  minAvailable: {{ .Values.budgetMinAvailable }}
   selector:
     matchLabels:
       {{- include "app.selectorLabels" . | nindent 6 }}
-{{- end -}}
 {{- end -}}

--- a/charts/eb7-base/values.yaml
+++ b/charts/eb7-base/values.yaml
@@ -102,13 +102,17 @@ healthCheckProbes:
 #   targetMemoryUtilizationPercentage: 80
 
 # Enable for Pod disruption budget
-# budget:
-#   minAvailable: 1
+# budgetMinAvailable: 1
 
 # Enable and set to anything to run on GPU nodes
 # Otherwise, it will run on CPU nodes
 # runOnGPU: true
 
+
+# Run On Local (false by default)
+# Setting it to true will disable non-essential resources
+# like pod affinity to be able to deploy on local cluster
+runOnLocal: false
 
 # Container command and args override
 # commandOverride: ["/bin/sh"]


### PR DESCRIPTION
Added a flag `runOnLocal` to disable auto pod affinity rules for local deployments.
Also changed the naming `budgetMinAvailable` to follow current convention