### PR TITLE
Add annotations to silent argo base syncronizations and deployments

### DIFF
--- a/charts/eb7-argo-base/templates/argo-application.yaml
+++ b/charts/eb7-argo-base/templates/argo-application.yaml
@@ -6,7 +6,7 @@ metadata:
   finalizers:
     - resources-finalizer.argocd.argoproj.io
   annotations:
-    - silent-notification: "true"
+    silent-notification: "true"
 spec:
   project: {{ .Values.appProject }}
 

--- a/charts/eb7-argo-base/templates/argo-application.yaml
+++ b/charts/eb7-argo-base/templates/argo-application.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Values.argoCDNamespace }}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
+  annotations:
+    - silent-notification: "true"
 spec:
   project: {{ .Values.appProject }}
 


### PR DESCRIPTION
This will exclude argocd chart app master notifs. That is mainly because each app deployment will refresh argocd base app and it will generate notifs.