### PR TITLE
DO-1022 Add custom metric support to hpa

### DIFF
--- a/charts/eb7-base/Chart.yaml
+++ b/charts/eb7-base/Chart.yaml
@@ -4,5 +4,5 @@ description: E-Bot7 Base App Helm Template
 
 type: application
 
-version: 0.2.10
-appVersion: 0.2.10
+version: 0.2.11
+appVersion: 0.2.11

--- a/charts/eb7-base/templates/hpa.yaml
+++ b/charts/eb7-base/templates/hpa.yaml
@@ -34,7 +34,7 @@ spec:
     {{- end }}
     {{- range $key,$val := .Values.autoscaling.podMetrics }}
     - type: Pods
-      pod:
+      pods:
         metric:
           name: {{ $key }}
         target:

--- a/charts/eb7-base/templates/hpa.yaml
+++ b/charts/eb7-base/templates/hpa.yaml
@@ -14,20 +14,38 @@ spec:
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
-    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.autoscaling.resourceMetrics.targetCPUUtilizationPercentage}}
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+          averageUtilization: {{ .Values.autoscaling.resourceMetrics.targetCPUUtilizationPercentage }}
     {{- end }}
-    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- if .Values.autoscaling.resourceMetrics.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
         target:
           type: Utilization
-          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+          averageUtilization: {{ .Values.autoscaling.resourceMetrics.targetMemoryUtilizationPercentage }}
+    {{- end }}
+    {{- range $key,$val := .Values.autoscaling.podMetrics }}
+    - type: Pods
+      pod:
+        metric:
+          name: {{ $key }}
+        target:
+          type: AverageValue
+          averageValue: {{ $val }}
+    {{- end }}
+    {{- range $key,$val := .Values.autoscaling.externalMetrics }}
+    - type: External
+      external:
+        metric:
+          name: {{ $key }}
+        target:
+          type: AverageValue
+          averageValue: {{ $val }}
     {{- end }}
 {{- end }}

--- a/charts/eb7-base/templates/hpa.yaml
+++ b/charts/eb7-base/templates/hpa.yaml
@@ -14,22 +14,22 @@ spec:
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
-    {{- if .Values.autoscaling.resourceMetrics }}
-    {{- if .Values.autoscaling.resourceMetrics.targetCPUUtilizationPercentage}}
+    {{- with .Values.autoscaling.resourceMetrics }}
+    {{- if .targetCPUUtilizationPercentage}}
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: {{ .Values.autoscaling.resourceMetrics.targetCPUUtilizationPercentage }}
+          averageUtilization: {{ .targetCPUUtilizationPercentage }}
     {{- end }}
-    {{- if .Values.autoscaling.resourceMetrics.targetMemoryUtilizationPercentage }}
+    {{- if .targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
         target:
           type: Utilization
-          averageUtilization: {{ .Values.autoscaling.resourceMetrics.targetMemoryUtilizationPercentage }}
+          averageUtilization: {{ .targetMemoryUtilizationPercentage }}
     {{- end }}
     {{- end }}
     {{- range $key,$val := .Values.autoscaling.podMetrics }}

--- a/charts/eb7-base/templates/hpa.yaml
+++ b/charts/eb7-base/templates/hpa.yaml
@@ -45,7 +45,7 @@ spec:
         metric:
           name: {{ $key }}
         target:
-          type: AverageValue
-          averageValue: {{ $val }}
+          type: Value
+          value: {{ $val }}
     {{- end }}
 {{- end }}

--- a/charts/eb7-base/templates/hpa.yaml
+++ b/charts/eb7-base/templates/hpa.yaml
@@ -14,6 +14,7 @@ spec:
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
+    {{- if .Values.autoscaling.resourceMetrics }}
     {{- if .Values.autoscaling.resourceMetrics.targetCPUUtilizationPercentage}}
     - type: Resource
       resource:
@@ -29,6 +30,7 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.resourceMetrics.targetMemoryUtilizationPercentage }}
+    {{- end }}
     {{- end }}
     {{- range $key,$val := .Values.autoscaling.podMetrics }}
     - type: Pods

--- a/charts/eb7-base/values.yaml
+++ b/charts/eb7-base/values.yaml
@@ -110,11 +110,18 @@ updateStrategy:
   maxUnavailable: 0
 
 # replicaCount: 1
-# autoscaling: 
+# autoscaling:
 #   minReplicas: 1
 #   maxReplicas: 10
-#   targetCPUUtilizationPercentage: 80
-#   targetMemoryUtilizationPercentage: 80
+#   resourceMetrics:
+#     targetCPUUtilizationPercentage: 80
+#     targetMemoryUtilizationPercentage: 80
+#   podMetrics:
+#     sample_metric: "1000m"
+#     sample2: "100k" 
+#   externalMetrics:
+#     ingress_name: "2" #number of requests
+
 
 # Enable for Pod disruption budget
 # budgetMinAvailable: 1


### PR DESCRIPTION
PR adds Custom and External Metric Support to HPA

The Following Autoscaling configuration
```
autoscaling:
  minReplicas: 1
  maxReplicas: 10
  resourceMetrics:
    targetCPUUtilizationPercentage: 80
    targetMemoryUtilizationPercentage: 80
  podMetrics:
    sample_metric: "1000m"
    sample2: "100k" 
  externalMetrics:
    ingress_name: "2" #number of requests
```
Generates the yaml file

```
# Source: eb7-base/templates/hpa.yaml
apiVersion: autoscaling/v2beta2
kind: HorizontalPodAutoscaler
metadata:
  name: eb7-base
  namespace: default
  labels:
    helm.sh/chart: eb7-base-0.2.8
    app.kubernetes.io/name: eb7-base
    app.kubernetes.io/instance: RELEASE-NAME
    app_name: eb7-base
    app.kubernetes.io/version: "0.2.8"
    app.kubernetes.io/managed-by: Helm
spec:
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: eb7-base
  minReplicas: 1
  maxReplicas: 10
  metrics:
    - type: Resource
      resource:
        name: cpu
        target:
          type: Utilization
          averageUtilization: 80
    - type: Resource
      resource:
        name: memory
        target:
          type: Utilization
          averageUtilization: 80
    - type: Pods
      pod:
        metric:
          name: sample2
        target:
          type: AverageValue
          averageValue: 100k
    - type: Pods
      pod:
        metric:
          name: sample_metric
        target:
          type: AverageValue
          averageValue: 1000m
    - type: External
      external:
        metric:
          name: ingress_name
        target:
          type: Value
          value: 2
```