### PR TITLE
Add manifest generate path to argocd base helm chart

### DIFF
--- a/charts/eb7-argo-base/Chart.yaml
+++ b/charts/eb7-argo-base/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.4
+version: 0.0.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.0.4
+appVersion: 0.0.5

--- a/charts/eb7-argo-base/templates/argo-application.yaml
+++ b/charts/eb7-argo-base/templates/argo-application.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: {{ .Values.argoCDNamespace }}
   finalizers:
     - resources-finalizer.argocd.argoproj.io
+  annotations:
+    # prevent re-generating cache for un-changed apps with shared repositories
+    argocd.argoproj.io/manifest-generate-paths: .
 spec:
   project: {{ .Values.appProject }}
 


### PR DESCRIPTION
This option will prevent re-generating cache for unchanged apps during updates using Webhook triggers: 

https://argo-cd.readthedocs.io/en/stable/operator-manual/high_availability/#webhook-and-manifest-paths-annotation


