### PR TITLE
add optional appNamespace option to eb7-argo-base template

### DIFF
--- a/charts/eb7-argo-base/Chart.yaml
+++ b/charts/eb7-argo-base/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.5
+version: 0.0.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.0.5
+appVersion: 0.0.6

--- a/charts/eb7-argo-base/templates/argo-application.yaml
+++ b/charts/eb7-argo-base/templates/argo-application.yaml
@@ -25,7 +25,7 @@ spec:
 
   destination:
     server: {{ .Values.destinationK8sServer }}
-    namespace: {{ .Values.appProject }}
+    namespace: {{ .Values.appNamespace | default .Values.appProject }}
 
   syncPolicy:
     {{- if .Values.automatedSync }}

--- a/charts/eb7-argo-base/values.yaml
+++ b/charts/eb7-argo-base/values.yaml
@@ -7,6 +7,7 @@
 
 # Application namespace and project
 appProject: "default"
+#appNamespace: "default" # Optional: It is usually the same as appProject
 
 # Helm settings
 helmRepoURL: "full-git-repo-url"


### PR DESCRIPTION
By adding this option we allow separating services belonging to a namespace to span over multiple ArgoCD projects.
Previously projects and namespaces considered as the same concept.