### PR TITLE
If possible, avoid putting the replicas on the same node.

### DIFF
--- a/charts/eb7-base/templates/deployment.yaml
+++ b/charts/eb7-base/templates/deployment.yaml
@@ -177,4 +177,21 @@ spec:
       {{- end }}
       {{- include "app.affinityTolerationRules" . | nindent 6 }}
       {{- include "app.SpreadConstraints" . | nindent 6 }}
+      affinity:
+        podAntiAffinity:
+          # If possible, avoid putting the replicas on the same node.
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 10
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - "{{ .Release.Name }}"
+                - key: app_name
+                  operator: In
+                  values:
+                  - "{{ include "app.name" . }}"
 {{- end }}


### PR DESCRIPTION
There were occasional issues on staging with the AP internal API which seemed to be related to spot instances, even though that deployment has two replicas. Setting the pod anti-affinity so that pods from the same deployment are preferably not on the same node should increase the fault-tolerance. This is adapted from configuration I've used in production in the past.

As an additional step, we could also set another anti-affinity using `topologyKey: topology.kubernetes.io/zone` with a lower weight to schedule replicas across availability zones.