### PR TITLE
Remove linkerd from default annotations and add K8S_HOST_IP env option

### DIFF
--- a/charts/eb7-base/Chart.yaml
+++ b/charts/eb7-base/Chart.yaml
@@ -4,5 +4,5 @@ description: E-Bot7 Base App Helm Template
 
 type: application
 
-version: 0.2.18
-appVersion: 0.2.18
+version: 0.2.19
+appVersion: 0.2.19

--- a/charts/eb7-base/templates/cronjob.yaml
+++ b/charts/eb7-base/templates/cronjob.yaml
@@ -32,14 +32,22 @@ spec:
               - configMapRef:
                   name: {{ include "app.fullname" $ }}
             {{- end }}
-            {{- with .Values.awsSecrets }}
+            {{- if or (.Values.awsSecrets) (.Values.addHostIPEnv) }}
             env:
+            {{- if .Values.addHostIPEnv }}
+              - name: "K8S_NODE_IP"
+                valueFrom:
+                  fieldRef:
+                    fieldPath: status.hostIP
+            {{- end }}
+            {{- with .Values.awsSecrets }}
             {{- range . }}
               - name: {{ .objectAlias | quote }}
                 valueFrom:
                   secretKeyRef:
                     key: {{ .objectAlias | quote }}
                     name: "{{ include "app.secretsProviderName" $ }}"
+            {{- end }}
             {{- end }}
             {{- end }}
             {{- with .Values.commandOverride }}

--- a/charts/eb7-base/templates/daemonset.yaml
+++ b/charts/eb7-base/templates/daemonset.yaml
@@ -90,14 +90,22 @@ spec:
             - configMapRef:
                 name: {{ include "app.fullname" $ }}
           {{- end }}
-          {{- with .Values.awsSecrets }}
+          {{- if or (.Values.awsSecrets) (.Values.addHostIPEnv) }}
           env:
+          {{- if .Values.addHostIPEnv }}
+            - name: "K8S_NODE_IP"
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          {{- end }}
+          {{- with .Values.awsSecrets }}
           {{- range . }}
             - name: {{ .objectAlias | quote }}
               valueFrom:
                 secretKeyRef:
                   key: {{ .objectAlias | quote }}
                   name: "{{ include "app.secretsProviderName" $ }}"
+          {{- end }}
           {{- end }}
           {{- end }}
           {{- if or (.Values.awsSecrets) (.Values.persistentVolumes) (.Values.hostVolumes) (.Values.enableSharedMemoryVolume) }}

--- a/charts/eb7-base/templates/deployment.yaml
+++ b/charts/eb7-base/templates/deployment.yaml
@@ -106,14 +106,22 @@ spec:
             - configMapRef:
                 name: {{ include "app.fullname" $ }}
           {{- end }}
-          {{- with .Values.awsSecrets }}
+          {{- if or (.Values.awsSecrets) (.Values.addHostIPEnv) }}
           env:
+          {{- if .Values.addHostIPEnv }}
+            - name: "K8S_NODE_IP"
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          {{- end }}
+          {{- with .Values.awsSecrets }}
           {{- range . }}
             - name: {{ .objectAlias | quote }}
               valueFrom:
                 secretKeyRef:
                   key: {{ .objectAlias | quote }}
                   name: "{{ include "app.secretsProviderName" $ }}"
+          {{- end }}
           {{- end }}
           {{- end }}
           {{- if or (.Values.awsSecrets) (.Values.persistentVolumes) (.Values.hostVolumes) (.Values.enableSharedMemoryVolume) }}

--- a/charts/eb7-base/templates/job.yaml
+++ b/charts/eb7-base/templates/job.yaml
@@ -28,14 +28,22 @@ spec:
           - configMapRef:
               name: {{ include "app.fullname" $ }}
         {{- end }}
-        {{- with .Values.awsSecrets }}
+        {{- if or (.Values.awsSecrets) (.Values.addHostIPEnv) }}
         env:
+        {{- if .Values.addHostIPEnv }}
+          - name: "K8S_NODE_IP"
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
+        {{- end }}
+        {{- with .Values.awsSecrets }}
         {{- range . }}
           - name: {{ .objectAlias | quote }}
             valueFrom:
               secretKeyRef:
                 key: {{ .objectAlias | quote }}
                 name: "{{ include "app.secretsProviderName" $ }}"
+        {{- end }}
         {{- end }}
         {{- end }}
         {{- with .Values.commandOverride }}

--- a/charts/eb7-base/values.yaml
+++ b/charts/eb7-base/values.yaml
@@ -12,6 +12,8 @@ namespace: "default"
 # It can be either Deployment or DaemonSet or CronJob or Job
 resourceType: "Deployment" 
 
+# Adds HOST_IP to Pod Environment variables (Required for Jaeger integration)
+# addHostIPEnv: true
 
 # environments:
 #   SAMPLE_ENV1: "Value1"
@@ -46,14 +48,13 @@ resourceType: "Deployment"
 serviceAccountName: default-sa
 
 annotations:
-  linkerd.io/inject: enabled
+  # linkerd.io/inject: enabled
   # log_index: my-index.my-app
-  # sidecar.jaegertracing.io/inject: "true"
 
 disableCloudwatchMetrics: 'true'
+
 # labels:
 #   environment: staging
-
 
 healthCheckProbes:
   failureThreshold: 5


### PR DESCRIPTION
Changes: 

- Removed linkerd from default annotations
- Added `K8S_NODE_IP` variable to allow pods to connect to DaemonSets like Jaeger