### PR TITLE
Add option `runOnDemand` to allow special pods to run on ON_DEMAND 

### DIFF
--- a/charts/eb7-base/Chart.yaml
+++ b/charts/eb7-base/Chart.yaml
@@ -4,5 +4,5 @@ description: E-Bot7 Base App Helm Template
 
 type: application
 
-version: 0.2.19
-appVersion: 0.2.19
+version: 0.2.20
+appVersion: 0.2.20

--- a/charts/eb7-base/templates/_helpers.tpl
+++ b/charts/eb7-base/templates/_helpers.tpl
@@ -80,6 +80,21 @@ tolerations:
     effect: NoSchedule
     value: gpu-nodes
     operator: Equal
+{{- else if .Values.runOnDemand -}}
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: eks.amazonaws.com/nodegroup
+          operator: In
+          values:
+          - gp-on-demand-nodes
+tolerations:
+  - key: nodegroup
+    effect: NoSchedule
+    value: gp-on-demand-nodes
+    operator: Equal
 {{- else -}}
 affinity:
   nodeAffinity:

--- a/charts/eb7-base/values.yaml
+++ b/charts/eb7-base/values.yaml
@@ -140,6 +140,11 @@ updateStrategy:
 # like pod affinity to be able to deploy on local cluster
 runOnLocal: false
 
+# This is a special option to allow special services/pods to run
+# On ON_DEMAND instances on EKS staging instead of SPOT instances
+# DO NOT USE IT FOR PRODUCTION !
+# runOnDemand: true
+
 
 # Container command and args override
 # commandOverride: ["/bin/sh"]


### PR DESCRIPTION
This option is only specific to EKS staging to allow special pods to be scheduled onto `ON_DEMAND` instances instead of `SPOT`

It should not be used for production