### PR TITLE
Change the order of memory and cpu utilization (HPA) for ArgoCD problem

### DIFF
--- a/charts/eb7-base/Chart.yaml
+++ b/charts/eb7-base/Chart.yaml
@@ -4,5 +4,5 @@ description: E-Bot7 Base App Helm Template
 
 type: application
 
-version: 0.2.20
-appVersion: 0.2.20
+version: 0.2.21
+appVersion: 0.2.21

--- a/charts/eb7-base/templates/hpa.yaml
+++ b/charts/eb7-base/templates/hpa.yaml
@@ -15,14 +15,6 @@ spec:
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
     {{- with .Values.autoscaling.resourceMetrics }}
-    {{- if .targetCPUUtilizationPercentage}}
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: {{ .targetCPUUtilizationPercentage }}
-    {{- end }}
     {{- if .targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
@@ -30,6 +22,14 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .targetMemoryUtilizationPercentage }}
+    {{- end }}
+    {{- if .targetCPUUtilizationPercentage}}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .targetCPUUtilizationPercentage }}
     {{- end }}
     {{- end }}
     {{- range $key,$val := .Values.autoscaling.podMetrics }}


### PR DESCRIPTION
Memory should come first otherwise ArgoCD will be stuck in a loop