### PR TITLE
Disable encryption in transit for EFS Persistent Volumes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ This is a sample e-bot7 helm chart repository. In order to use and deploy this c
 Obviously you also need a working EKS K8S cluster with the related kubeconfig file usually in `~/.kube/config`
 
 
+Add this chart to your local helm chart repositories:
+```bash
+$ helm repo add eb7-base https://ebot7.github.io/helm-charts
+$ helm repo update
+```
+
+
 You can try to check if your templates are working correct, you can try dry-run as follows
 ```bash
 $ helm install --dry-run eb7-base charts/eb7-base

--- a/charts/eb7-base/Chart.yaml
+++ b/charts/eb7-base/Chart.yaml
@@ -4,5 +4,5 @@ description: E-Bot7 Base App Helm Template
 
 type: application
 
-version: 0.2.22
-appVersion: 0.2.22
+version: 0.2.23
+appVersion: 0.2.23

--- a/charts/eb7-base/templates/cronjob.yaml
+++ b/charts/eb7-base/templates/cronjob.yaml
@@ -110,6 +110,7 @@ spec:
             {{- range . }}
               - name: {{ .name }}
                 mountPath: {{ .mountPath }}
+                subPath: {{ include "app.fullname" $ }}-{{ .name }}
             {{- end }}
             {{- end }}
             {{- end }}
@@ -143,7 +144,7 @@ spec:
           {{- range . }}
             - name: {{ .name }}
               persistentVolumeClaim:
-                claimName: {{ .name }}
+                claimName: {{ include "app.fullname" $ }}-{{ .name }}
           {{- end }}
           {{- end }}
           {{- end }}

--- a/charts/eb7-base/templates/daemonset.yaml
+++ b/charts/eb7-base/templates/daemonset.yaml
@@ -130,6 +130,7 @@ spec:
           {{- range . }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
+              subPath: {{ include "app.fullname" $ }}-{{ .name }}
           {{- end }}
           {{- end }}
           {{- end }}
@@ -160,7 +161,7 @@ spec:
       {{- range . }}
         - name: {{ .name }}
           persistentVolumeClaim:
-            claimName: {{ .name }}
+            claimName: {{ include "app.fullname" $ }}-{{ .name }}
       {{- end }}
       {{- end }}
       {{- end }}

--- a/charts/eb7-base/templates/deployment.yaml
+++ b/charts/eb7-base/templates/deployment.yaml
@@ -146,6 +146,7 @@ spec:
           {{- range . }}
             - name: {{ .name }}
               mountPath: {{ .mountPath }}
+              subPath: {{ include "app.fullname" $ }}-{{ .name }}
           {{- end }}
           {{- end }}
           {{- end }}
@@ -176,7 +177,7 @@ spec:
       {{- range . }}
         - name: {{ .name }}
           persistentVolumeClaim:
-            claimName: {{ .name }}
+            claimName: {{ include "app.fullname" $ }}-{{ .name }}
       {{- end }}
       {{- end }}
       {{- end }}

--- a/charts/eb7-base/templates/efs-pvc.yaml
+++ b/charts/eb7-base/templates/efs-pvc.yaml
@@ -1,17 +1,38 @@
 {{- with .Values.persistentVolumes -}}
 {{- range . }}
 apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ include "app.fullname" $ }}-{{ .name }}
+spec:
+  capacity:
+    storage: 5Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  claimRef:
+    namespace: {{ $.Values.namespace | default "default" }}
+    name: {{ include "app.fullname" $ }}-{{ .name }}
+  csi:
+    driver: efs.csi.aws.com
+    volumeHandle: {{ .efsID }}
+    volumeAttributes:
+      encryptInTransit: "false"
+---
+apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .name }}
+  name: {{ include "app.fullname" $ }}-{{ .name }}
   namespace: {{ $.Values.namespace | default "default" }}
 spec:
   accessModes:
     - ReadWriteMany
-  storageClassName: {{ .storageClassName }}
+  storageClassName: ""
   resources:
     requests:
-      storage: {{ .size | default "5G" }}
+      storage: 5Gi
 ---
 {{- end -}}
 {{- end -}}

--- a/charts/eb7-base/templates/job.yaml
+++ b/charts/eb7-base/templates/job.yaml
@@ -106,6 +106,7 @@ spec:
         {{- range . }}
           - name: {{ .name }}
             mountPath: {{ .mountPath }}
+            subPath: {{ include "app.fullname" $ }}-{{ .name }}
         {{- end }}
         {{- end }}
         {{- end }}
@@ -139,7 +140,7 @@ spec:
       {{- range . }}
         - name: {{ .name }}
           persistentVolumeClaim:
-            claimName: {{ .name }}
+            claimName: {{ include "app.fullname" $ }}-{{ .name }}
       {{- end }}
       {{- end }}
       {{- end }}

--- a/charts/eb7-base/values.yaml
+++ b/charts/eb7-base/values.yaml
@@ -95,12 +95,10 @@ healthCheckProbes:
 # persistentVolumes:
 #   - name: efs-pvc1
 #     mountPath: /var/lib/efs-pvc1
-#     storageClassName: efs-generic
-#     size: 5G # Optional
+#     efsID: fs-xxxxxxxxx
 #   - name: efs-pvc2
 #     mountPath: /var/lib/efs-pvc2
-#     storageClassName: efs-generic
-#     size: 5G # Optional
+#     efsID: fs-xxxxxxxxx
 
 # It mounts /dev/shm for specific containers
 # enableSharedMemoryVolume: false


### PR DESCRIPTION
This PR disables encryption in transit by default for all EFS persistent volumes
 
* Previous volume data need migrations/recreations