### PR TITLE
Allow generic ArgoCD apps using base templates

### DIFF
--- a/charts/eb7-argo-base/Chart.yaml
+++ b/charts/eb7-argo-base/Chart.yaml
@@ -1,21 +1,7 @@
 apiVersion: v2
 name: eb7-argo-base
 description: E-Bot7 Base Helm Template for ArgoCD Apps
-
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
 
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-version: 0.0.6
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application.
-appVersion: 0.0.6
+version: 0.0.7
+appVersion: 0.0.7

--- a/charts/eb7-argo-base/templates/argo-application.yaml
+++ b/charts/eb7-argo-base/templates/argo-application.yaml
@@ -14,14 +14,20 @@ spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
 
   source:
-    repoURL: {{ .Values.helmRepoURL }}
-    targetRevision: {{ .Values.helmRepoBranch }}
-    path: {{ .Values.HelmChartPath }}
+    repoURL: {{ .Values.helmRepoURL | default .Values.gitRepoURL }}
+    targetRevision: {{ .Values.helmRepoBranch | default  .Values.gitRepoBranch }}
+    path: {{ .Values.HelmChartPath | default .Values.gitRepoPath }}
 
+    {{- if .Values.helmRepoURL }}
     helm:
       valueFiles:
         - {{ .Values.helmValuesFile }}
       version: {{ .Values.helmVersion }}
+    {{- end }}
+  
+  {{- with .Values.ignoreDifferences }}
+  ignoreDifferences: {{ toYaml . | nindent 4 }}
+  {{- end }}
 
   destination:
     server: {{ .Values.destinationK8sServer }}
@@ -39,6 +45,7 @@ spec:
     - CreateNamespace={{ .Values.syncCreateNamespace }} 
     - PrunePropagationPolicy={{ .Values.syncPrunePropagationPolicy }} 
     - PruneLast={{ .Values.syncPruneLast }}
+    - RespectIgnoreDifferences={{ .Values.syncRespectIgnoreDifferences }}
 
     retry:
       limit: {{ .Values.retryLimit }} 

--- a/charts/eb7-argo-base/values.yaml
+++ b/charts/eb7-argo-base/values.yaml
@@ -16,6 +16,19 @@ HelmChartPath: "sample-chart/"
 helmValuesFile: "values.yaml"
 
 
+# Generic GitRepo Settings (Works only if helm values are not used)
+# gitRepoURL: "full-git-repo-url"
+# gitRepoBranch: "master"
+# gitRepoPath: "sample-generic-path/"
+
+
+# ignoreDifferences:
+# - kind: ClusterRole
+#   group: rbac.authorization.k8s.io
+#   jsonPointers:
+#   - /rules
+
+
 ############################################################################
 ## Settings that SHOULD NOT be changed unless you know what are you doing ##
 ############################################################################
@@ -60,6 +73,9 @@ syncPrunePropagationPolicy: "foreground"
 
 # Allow the ability for resource pruning to happen as a final, implicit wave of a sync operation
 syncPruneLast: true
+
+# Make sure that ArgoCD respects ignore differences block
+syncRespectIgnoreDifferences: true
 
 
 # RETRY OPTIONS


### PR DESCRIPTION
We need generic ArgoCD (not only Helm) apps for stacks like Kubeflow based on Kustomize