### PR TITLE
Add new resource type to the eb7-base: BlueGreenWeights

### DIFF
--- a/charts/eb7-base/Chart.yaml
+++ b/charts/eb7-base/Chart.yaml
@@ -4,5 +4,5 @@ description: E-Bot7 Base App Helm Template
 
 type: application
 
-version: 0.2.23
-appVersion: 0.2.23
+version: 0.2.24
+appVersion: 0.2.24

--- a/charts/eb7-base/templates/blue-green-weights.yaml
+++ b/charts/eb7-base/templates/blue-green-weights.yaml
@@ -1,0 +1,18 @@
+{{- if eq .Values.resourceType "BlueGreenWeights" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "app.fullname" . }}
+  namespace: {{ .Values.namespace | default "default" }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook-weight": "-2"
+data:
+{{- with .Values.blueGreenWeights }}
+  blue_name: "{{ .blue_name }}"
+  blue_weight: "{{ .blue_weight }}"
+  green_name: "{{ .green_name }}"
+  green_weight: "{{ .green_weight }}"
+{{- end }}
+{{- end -}}

--- a/charts/eb7-base/values.yaml
+++ b/charts/eb7-base/values.yaml
@@ -9,7 +9,7 @@ image:
 
 namespace: "default"
 
-# It can be either Deployment or DaemonSet or CronJob or Job
+# It can be either Deployment, DaemonSet, CronJob, Job or BlueGreenWeights
 resourceType: "Deployment" 
 
 # Adds HOST_IP to Pod Environment variables (Required for Jaeger integration)
@@ -143,6 +143,13 @@ runOnLocal: false
 # DO NOT USE IT FOR PRODUCTION !
 # runOnDemand: true
 
+
+# Blue/Green Weights (if enabled by resourceType)
+# blueGreenWeights:
+#   blue_name: "test-app-2"
+#   blue_weight: "80"
+#   green_name: "test-app-3"
+#   green_weight: "20"
 
 # Container command and args override
 # commandOverride: ["/bin/sh"]


### PR DESCRIPTION
This PR allows a new resource type `BlueGreenWeights` to be deployed by developers which allows to specify and change blue/green service traffic weights