### PR TITLE
Enable injecting the pod name as an env var

### DIFF
--- a/charts/eb7-base/templates/deployment.yaml
+++ b/charts/eb7-base/templates/deployment.yaml
@@ -114,6 +114,12 @@ spec:
                 fieldRef:
                   fieldPath: status.hostIP
           {{- end }}
+          {{- if .Values.addPodNameEnv }}
+            - name: "K8S_POD_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          {{- end }}
           {{- with .Values.awsSecrets }}
           {{- range . }}
             - name: {{ .objectAlias | quote }}

--- a/charts/eb7-base/values.yaml
+++ b/charts/eb7-base/values.yaml
@@ -15,6 +15,9 @@ resourceType: "Deployment"
 # Adds HOST_IP to Pod Environment variables (Required for Jaeger integration)
 # addHostIPEnv: true
 
+# Add K8S_POD_NAME to Pod Environment variables
+# addPodNameEnv: true
+
 # environments:
 #   SAMPLE_ENV1: "Value1"
 #   SAMPLE_ENV2: "Value2"


### PR DESCRIPTION
Kafka clients should have a unique client id, and using the pod name would be ideal, as it's not only unique but clearly identifiable. This PR uses the k8s downward API to optionally expose the pod name to the containers as an environment variable, similarly to the way the host IP is already exposed.