### PR TITLE
Add helm chart hooks functionality and pod_name env

### DIFF
--- a/charts/eb7-base/Chart.yaml
+++ b/charts/eb7-base/Chart.yaml
@@ -4,5 +4,5 @@ description: E-Bot7 Base App Helm Template
 
 type: application
 
-version: 0.2.24
-appVersion: 0.2.24
+version: 0.2.25
+appVersion: 0.2.25

--- a/charts/eb7-base/templates/_helpers.tpl
+++ b/charts/eb7-base/templates/_helpers.tpl
@@ -16,6 +16,24 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Hook full name (if any)
+*/}}
+{{- define "hook.fullname" -}}
+hook-{{ include "app.name" . }}
+{{- end -}}
+
+{{/*
+hook-secret-name (if any)
+*/}}
+{{- define "hook.secretsProviderName" -}}
+{{- if .Values.hookValues.awsSecrets -}}
+{{ include "hook.fullname" . }}-{{ .Values.hookValues.awsSecrets | toString | adler32sum | trunc 10 }}
+{{- else -}}
+{{ include "hook.fullname" . }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "app.chart" -}}

--- a/charts/eb7-base/templates/daemonset.yaml
+++ b/charts/eb7-base/templates/daemonset.yaml
@@ -90,13 +90,19 @@ spec:
             - configMapRef:
                 name: {{ include "app.fullname" $ }}
           {{- end }}
-          {{- if or (.Values.awsSecrets) (.Values.addHostIPEnv) }}
+          {{- if or (.Values.awsSecrets) (.Values.addHostIPEnv) (.Values.addPodNameEnv) }}
           env:
           {{- if .Values.addHostIPEnv }}
             - name: "K8S_NODE_IP"
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+          {{- end }}
+          {{- if .Values.addPodNameEnv }}
+            - name: "K8S_POD_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           {{- end }}
           {{- with .Values.awsSecrets }}
           {{- range . }}

--- a/charts/eb7-base/templates/deployment.yaml
+++ b/charts/eb7-base/templates/deployment.yaml
@@ -106,13 +106,19 @@ spec:
             - configMapRef:
                 name: {{ include "app.fullname" $ }}
           {{- end }}
-          {{- if or (.Values.awsSecrets) (.Values.addHostIPEnv) }}
+          {{- if or (.Values.awsSecrets) (.Values.addHostIPEnv) (.Values.addPodNameEnv) }}
           env:
           {{- if .Values.addHostIPEnv }}
             - name: "K8S_NODE_IP"
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+          {{- end }}
+          {{- if .Values.addPodNameEnv }}
+            - name: "K8S_POD_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           {{- end }}
           {{- with .Values.awsSecrets }}
           {{- range . }}

--- a/charts/eb7-base/templates/hooks/hook-configmap.yaml
+++ b/charts/eb7-base/templates/hooks/hook-configmap.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.hookValues }}
+{{- if .Values.hookValues.environments -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "hook.fullname" . }}
+  namespace: {{ .Values.namespace | default "default" }}
+  labels:
+    {{- include "app.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": {{ .Values.hookValues.hookType | default "post-install" }} 
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed,before-hook-creation"
+data:
+{{- range $k, $v := .Values.hookValues.environments }}
+  {{ $k }}: {{ $v | quote }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/eb7-base/templates/hooks/hook-job.yaml
+++ b/charts/eb7-base/templates/hooks/hook-job.yaml
@@ -1,0 +1,135 @@
+{{- if .Values.hookValues }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "hook.fullname" . }}
+  namespace: {{ .Values.namespace | default "default" }}
+  labels:
+    {{- include "app.selectorLabels" . | nindent 4 }}
+  annotations: 
+    aws.amazon.com/cloudwatch-agent-ignore: "{{ .Values.disableCloudwatchMetrics }}"
+    {{- with .Values.annotations }} {{- toYaml . | nindent 4 }} {{- end }}
+    "helm.sh/hook": {{ .Values.hookValues.hookType | default "post-install" }} 
+    "helm.sh/hook-weight": {{ .Values.hookValues.hookWeight | default "-5" | quote }} 
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed,before-hook-creation"
+spec:
+  backoffLimit: {{ or .Values.hookValues.backoffLimit .Values.backoffLimit 4 }}
+  activeDeadlineSeconds : {{ or .Values.hookValues.activeDeadlineSeconds .Values.activeDeadlineSeconds 3600 }}
+  template:
+    metadata:
+      annotations:
+        checksum/configmap: {{ include (print $.Template.BasePath "/hooks/hook-configmap.yaml") . | sha256sum }}
+        checksum/secretprovider: {{ include (print $.Template.BasePath "/hooks/hook-secret-provider.yaml") . | sha256sum }}
+        aws.amazon.com/cloudwatch-agent-ignore: "{{ .Values.disableCloudwatchMetrics }}"
+        {{- with .Values.annotations }} {{- toYaml . | nindent 8 }} {{- end }}
+      labels:
+        {{- include "app.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ .Values.serviceAccountName }}
+      {{- with .Values.jobSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image:  "{{ .Values.hookValues.imageRepository | default .Values.image.repository }}:{{ .Values.hookValues.imageTag | default .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.hookValues.imagePullPolicy | default .Values.image.pullPolicy }}
+        {{- if .Values.hookValues.inheritEnvironments }}
+        {{- with .Values.environments }}
+        envFrom:
+          - configMapRef:
+              name: {{ include "app.fullname" $ }}
+        {{- end }}
+        {{- end }}
+        {{- with .Values.hookValues.environments }}
+        envFrom:
+          - configMapRef:
+              name: {{ include "hook.fullname" $ }}
+        {{- end }}
+        {{- if or (.Values.hookValues.inheritAwsSecrets) (.Values.hookValues.awsSecrets) }}
+        env:
+        {{- if .Values.hookValues.inheritAwsSecrets }}
+        {{- with .Values.awsSecrets }}
+        {{- range . }}
+          - name: {{ .objectAlias | quote }}
+            valueFrom:
+              secretKeyRef:
+                key: {{ .objectAlias | quote }}
+                name: "{{ include "app.secretsProviderName" $ }}"
+        {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- with .Values.hookValues.awsSecrets }}
+        {{- range . }}
+          - name: {{ .objectAlias | quote }}
+            valueFrom:
+              secretKeyRef:
+                key: {{ .objectAlias | quote }}
+                name: "{{ include "hook.secretsProviderName" $ }}"
+        {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- with .Values.hookValues.commandOverride }}
+        command: {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.hookValues.argsOverride }}
+        args: {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.hookValues.resources }}
+        resources:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with .Values.hookValues.servicePorts }}
+        ports:
+        {{- range . }}
+          - containerPort: {{ .targetPort }}
+            protocol: {{ .protocol | default "TCP" }}
+            name: {{ .name }}
+        {{- end }}
+        {{- end }}
+        {{- with .Values.hookValues.podSecurityContext }}
+        securityContext:
+        {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with .Values.hookValues.lifecycle }}
+        lifecycle:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- if or (.Values.hookValues.inheritAwsSecrets) (.Values.hookValues.awsSecrets) }}
+        volumeMounts:
+        {{- if .Values.hookValues.inheritAwsSecrets }}
+          - mountPath: /mnt/secrets-store-inherit
+            name: secrets-store-inline-inherit
+            readOnly: true
+        {{- end }}
+        {{- if .Values.hookValues.awsSecrets }}
+          - mountPath: /mnt/secrets-store
+            name: secrets-store-inline
+            readOnly: true
+        {{- end }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if or (.Values.hookValues.inheritAwsSecrets) (.Values.hookValues.awsSecrets) }}
+      volumes:
+      {{- if .Values.hookValues.inheritAwsSecrets }}
+        - name: secrets-store-inline-inherit
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: {{ include "app.secretsProviderName" $ }}
+      {{- end }}
+      {{- if .Values.hookValues.awsSecrets }}
+        - name: secrets-store-inline
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: {{ include "hook.secretsProviderName" $ }}
+      {{- end }}
+      {{- end }}
+      restartPolicy: {{ .Values.hookValues.restartPolicy | default "Never" }}
+{{- end }}

--- a/charts/eb7-base/templates/hooks/hook-job.yaml
+++ b/charts/eb7-base/templates/hooks/hook-job.yaml
@@ -10,7 +10,7 @@ metadata:
     aws.amazon.com/cloudwatch-agent-ignore: "{{ .Values.disableCloudwatchMetrics }}"
     {{- with .Values.annotations }} {{- toYaml . | nindent 4 }} {{- end }}
     "helm.sh/hook": {{ .Values.hookValues.hookType | default "post-install" }} 
-    "helm.sh/hook-weight": {{ .Values.hookValues.hookWeight | default "-5" | quote }} 
+    "helm.sh/hook-weight": "-6"
     "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed,before-hook-creation"
 spec:
   backoffLimit: {{ or .Values.hookValues.backoffLimit .Values.backoffLimit 4 }}

--- a/charts/eb7-base/templates/hooks/hook-secret-provider.yaml
+++ b/charts/eb7-base/templates/hooks/hook-secret-provider.yaml
@@ -1,17 +1,20 @@
-{{- if .Values.awsSecrets -}}
+{{- if .Values.hookValues }}
+{{- if .Values.hookValues.awsSecrets -}}
 apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
-  name: {{ include "app.secretsProviderName" . }}
+  name: {{ include "hook.secretsProviderName" . }}
   namespace: {{ .Values.namespace | default "default" }}
   labels:
     {{- include "app.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook": {{ .Values.hookValues.hookType | default "post-install" }} 
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed,before-hook-creation"
 spec:
   parameters:
     objects: |
-      {{- range .Values.awsSecrets }}
+      {{- range .Values.hookValues.awsSecrets }}
       - objectAlias: {{ .objectAlias | quote }}
         objectType: "secretsmanager"
         objectName: {{ .objectName | quote  }}
@@ -20,10 +23,11 @@ spec:
   provider: aws
   secretObjects:
     - data:
-       {{- range .Values.awsSecrets }}
+       {{- range .Values.hookValues.awsSecrets }}
         - key: {{ .objectAlias | quote }}
           objectName: {{ .objectAlias | quote }}
         {{- end }}
-      secretName: {{ include "app.secretsProviderName" . }}
+      secretName: {{ include "hook.secretsProviderName" . }}
       type: Opaque
+{{- end -}}
 {{- end -}}

--- a/charts/eb7-base/values.yaml
+++ b/charts/eb7-base/values.yaml
@@ -15,6 +15,9 @@ resourceType: "Deployment"
 # Adds HOST_IP to Pod Environment variables (Required for Jaeger integration)
 # addHostIPEnv: true
 
+# Add K8S_POD_NAME to Pod Environment variables
+# addPodNameEnv: true
+
 # environments:
 #   SAMPLE_ENV1: "Value1"
 #   SAMPLE_ENV2: "Value2"
@@ -178,3 +181,32 @@ runOnLocal: false
 # priorityClassName: "system-node-critical"
 
 # schedule: "0 5 * * *"
+
+# hookValues:
+#   imageRepository: "my-hook-repository"
+#   imageTag: "my-hook-tag"
+#   imagePullPolicy: "IfNotPresent"
+
+#   hookType: "post-install"
+#   hookWeight: "-5"
+
+#   commandOverride: ["/bin/sh"]
+#   argsOverride: [
+#     "-c",
+#     "while true; do echo sleeping; sleep 10; done"
+#   ]
+
+#   environments:
+#     SAMPLE_ENV1: "Value1"
+#     SAMPLE_ENV2: "Value2"
+
+#   awsSecrets:
+#   - objectAlias: SECRET1
+#     objectType: secretsmanager
+#     objectName: 'ARN1'
+#   - objectAlias: SECRET2
+#     objectType: secretsmanager
+#     objectName: 'ARN2'
+
+#   inheritAwsSecrets: true
+#   inheritEnvironments: true

--- a/charts/eb7-base/values.yaml
+++ b/charts/eb7-base/values.yaml
@@ -188,7 +188,6 @@ runOnLocal: false
 #   imagePullPolicy: "IfNotPresent"
 
 #   hookType: "post-install"
-#   hookWeight: "-5"
 
 #   commandOverride: ["/bin/sh"]
 #   argsOverride: [


### PR DESCRIPTION
This PR adds hooks functionality to the base helm charts. Now you can define all possible values using `hookValues` inside `values.yaml` file to provide a helm chart hook to be executed before or after the deployments. It is also possible to fetch secrets from the AWS Secrets Manager. 
The new `addPodNameEnv` is also added to allow deployments to fetch the pod name via ENV variables.