### PR TITLE
Add runOnBlue option to separate non-live pods into dedicated node groups

### DIFF
--- a/charts/eb7-base/Chart.yaml
+++ b/charts/eb7-base/Chart.yaml
@@ -4,5 +4,5 @@ description: E-Bot7 Base App Helm Template
 
 type: application
 
-version: 0.2.26
-appVersion: 0.2.26
+version: 0.2.27
+appVersion: 0.2.27

--- a/charts/eb7-base/templates/_helpers.tpl
+++ b/charts/eb7-base/templates/_helpers.tpl
@@ -127,6 +127,15 @@ tolerations:
     effect: NoSchedule
     value: gp-on-demand-nodes
     operator: Equal
+{{- else if .Values.runOnBlue }}
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: eks.amazonaws.com/nodegroup
+          operator: In
+          values:
+          - gp-blue-nodes
 {{- else }}
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:

--- a/charts/eb7-base/values.yaml
+++ b/charts/eb7-base/values.yaml
@@ -135,11 +135,15 @@ updateStrategy:
 # Otherwise, it will run on CPU nodes
 # runOnGPU: true
 
-
 # Run On Local (false by default)
 # Setting it to true will disable non-essential resources
 # like pod affinity to be able to deploy on local cluster
 runOnLocal: false
+
+# This is a special option to allow blue/non-live services/pods to run
+# On GP-BLUE instances on EKS PRODUCTION instead of GP instances.
+# It only works on PRODUCTION !
+# runOnBlue: true
 
 # This is a special option to allow special services/pods to run
 # On ON_DEMAND instances on EKS staging instead of SPOT instances


### PR DESCRIPTION
It only works on production 