### PR TITLE
Fix indentation of cronjob comands

### DIFF
--- a/charts/eb7-base/Chart.yaml
+++ b/charts/eb7-base/Chart.yaml
@@ -4,5 +4,5 @@ description: E-Bot7 Base App Helm Template
 
 type: application
 
-version: 0.2.28
-appVersion: 0.2.28
+version: 0.2.29
+appVersion: 0.2.29

--- a/charts/eb7-base/templates/cronjob.yaml
+++ b/charts/eb7-base/templates/cronjob.yaml
@@ -63,10 +63,10 @@ spec:
             {{- end }}
             {{- end }}
             {{- with .Values.commandOverride }}
-            command: {{- toYaml . | nindent 10 }}
+            command: {{- toYaml . | nindent 14 }}
             {{- end }}
             {{- with .Values.argsOverride }}
-            args: {{- toYaml . | nindent 10 }}
+            args: {{- toYaml . | nindent 14 }}
             {{- end }}
             {{- with .Values.resources }}
             resources:


### PR DESCRIPTION
I ran into this issue when setting up a cron job. I guess this code was taken from the deployment, where the indentation is slightly different.